### PR TITLE
llvm: Apply GCC 15-related cstdint fixes

### DIFF
--- a/llvm/0022-ADT-Add-cstdint-to-SmallVector-101761.patch
+++ b/llvm/0022-ADT-Add-cstdint-to-SmallVector-101761.patch
@@ -1,0 +1,34 @@
+From 51d88407c1ae86c3b3c7b497d049f8980f2a3510 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 2 Aug 2024 23:07:21 +0100
+Subject: [PATCH 22/25] [ADT] Add `<cstdint>` to SmallVector (#101761)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+SmallVector uses `uint32_t`, `uint64_t` without including `<cstdint>`
+which fails to build w/ GCC 15 after a change in libstdc++ [0]
+
+[0] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=3a817a4a5a6d94da9127af3be9f84a74e3076ee2
+
+Gentoo-Component: llvm
+Signed-off-by: Michał Górny <mgorny@gentoo.org>
+---
+ llvm/include/llvm/ADT/SmallVector.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/include/llvm/ADT/SmallVector.h b/llvm/include/llvm/ADT/SmallVector.h
+index e34702bdbb3c..1c0f3465b2a9 100644
+--- a/llvm/include/llvm/ADT/SmallVector.h
++++ b/llvm/include/llvm/ADT/SmallVector.h
+@@ -19,6 +19,7 @@
+ #include <algorithm>
+ #include <cassert>
+ #include <cstddef>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
+ #include <functional>
+-- 
+2.46.0
+

--- a/llvm/0023-AMDGPU-Include-cstdint-in-AMDGPUMCTargetDesc-101766.patch
+++ b/llvm/0023-AMDGPU-Include-cstdint-in-AMDGPUMCTargetDesc-101766.patch
@@ -1,0 +1,30 @@
+From 000f92beb459096534a7bfaa8c5e99d77b7594c1 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Sat, 3 Aug 2024 06:36:43 +0100
+Subject: [PATCH 23/25] [AMDGPU] Include `<cstdint>` in AMDGPUMCTargetDesc
+ (#101766)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Gentoo-Component: llvm
+Signed-off-by: Michał Górny <mgorny@gentoo.org>
+---
+ llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
+index c2e2563c3989..53aac8934100 100644
+--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
++++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
+@@ -15,6 +15,7 @@
+ #ifndef LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCTARGETDESC_H
+ #define LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ 
+ namespace llvm {
+-- 
+2.46.0
+

--- a/llvm/0024-Another-gcc-15-fix-from-Sam-James.patch
+++ b/llvm/0024-Another-gcc-15-fix-from-Sam-James.patch
@@ -1,0 +1,30 @@
+From 67fc0069c285b37f09d408aae43c37b8afdf11f7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Sat, 3 Aug 2024 12:01:20 +0200
+Subject: [PATCH 24/25] Another gcc-15 fix from Sam James
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Bug: https://bugs.gentoo.org/937164
+Gentoo-Component: llvm
+Signed-off-by: Michał Górny <mgorny@gentoo.org>
+---
+ llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+index d0530bd4d650..10b59462aebe 100644
+--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
++++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+@@ -13,6 +13,7 @@
+ #ifndef LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
+ #define LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ #include <string>
+ 
+-- 
+2.46.0
+

--- a/llvm/0025-include-cstdint.patch
+++ b/llvm/0025-include-cstdint.patch
@@ -1,0 +1,30 @@
+From 735207ac16bb15d88116bf00283eb0135ed2585a Mon Sep 17 00:00:00 2001
+From: Paul Zander <negril.nx+gentoo@gmail.com>
+Date: Thu, 22 Aug 2024 11:40:13 +0200
+Subject: [PATCH 25/25] include cstdint
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Gentoo-Component: compiler-rt
+Signed-off-by: Paul Zander <negril.nx+gentoo@gmail.com>
+Signed-off-by: Michał Górny <mgorny@gentoo.org>
+---
+ compiler-rt/lib/orc/error.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/compiler-rt/lib/orc/error.h b/compiler-rt/lib/orc/error.h
+index 92ac5a884ac6..33a599f71149 100644
+--- a/compiler-rt/lib/orc/error.h
++++ b/compiler-rt/lib/orc/error.h
+@@ -14,6 +14,7 @@
+ #include "stl_extras.h"
+ 
+ #include <cassert>
++#include <cstdint>
+ #include <memory>
+ #include <string>
+ #include <type_traits>
+-- 
+2.46.0
+

--- a/llvm/PKGBUILD
+++ b/llvm/PKGBUILD
@@ -6,8 +6,16 @@ arch=('any')
 url="https://clang.llvm.org/"
 license=('Apache-2.0 WITH LLVM-exception')
 options=(!strip libtool staticlibs)
-source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-$pkgver/llvm-project-$pkgver.src.tar.xz")
-sha256sums=('8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a')
+source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-$pkgver/llvm-project-$pkgver.src.tar.xz"
+        "0022-ADT-Add-cstdint-to-SmallVector-101761.patch"
+        "0023-AMDGPU-Include-cstdint-in-AMDGPUMCTargetDesc-101766.patch"
+        "0024-Another-gcc-15-fix-from-Sam-James.patch"
+        "0025-include-cstdint.patch")
+sha256sums=('8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a'
+            'dc4a9be30bf281f340c2f8142c6bcc885a208906661c52eff9b11993bcdc7b00'
+            '3a690c2fd6b9bc9ac575db7067699787f6d07b21c5d43accba6bdf3335dadad3'
+            '1b7d7b8d1cdaa6c4fc1d76f6cc339fe1e5b4d3a99a0cce847dff81464fb7e938'
+            'd3ffc972a7b88dbe2d9ff1fad6e9ab9042c22d48faf2041f5fb7524b86cef1bd')
 groups=('ps5-payload-dev')
 makedepends=('ps5-payload-sdk')
 
@@ -17,6 +25,14 @@ prepare() {
     fi
 
     cd llvm-project-$pkgver.src
+
+    # Include cstdint; fixes building with GCC 15
+    # https://dev.gentoo.org/~mgorny/dist/llvm/llvm-gentoo-patchset-15.0.7-r7.tar.xz
+    patch -Np1 -i ../0022-ADT-Add-cstdint-to-SmallVector-101761.patch
+    patch -Np1 -i ../0023-AMDGPU-Include-cstdint-in-AMDGPUMCTargetDesc-101766.patch
+    patch -Np1 -i ../0024-Another-gcc-15-fix-from-Sam-James.patch
+    patch -Np1 -i ../0025-include-cstdint.patch
+
     cmake -S llvm -B host \
           -DCMAKE_BUILD_TYPE=Release \
           -DLLVM_ENABLE_PROJECTS=""


### PR DESCRIPTION
A change in GCC 15 broke LLVM builds up to version 19 (see llvm/llvm-project#101761). These patches have been applied upstream and backported in most cases, but not as far as LLVM 14.

I've copied these patches in from Gentoo's llvm-gentoo-patchset-15.0.7-r7, but they apply the same to LLVM 14. Only patches 0022, 0023, and 0024 are needed for this PKGBUILD, but for completeness I've included 0025 as well.