### PR TITLE
osmesa: Delete glu patch

### DIFF
--- a/osmesa/PKGBUILD
+++ b/osmesa/PKGBUILD
@@ -19,7 +19,6 @@ prepare() {
     fi
     cd osmesa
     sed -i 's|add_library(osmesa SHARED|add_library(osmesa|g' src/CMakeLists.txt
-    sed -i 's|add_library(glu SHARED|add_library(glu|g' examples/glu/CMakeLists.txt
 }
 
 build() {


### PR DESCRIPTION
When running osmesa's `prepare()` function, the PKGBUILD tries to patch `examples/glu/CMakeLists.txt`, but there is no `examples/glu`. Removing this line allows the build to proceed as normal.