### PR TITLE
Add missing ps5-payload-* makedepends

### DIFF
--- a/SDL2/PKGBUILD
+++ b/SDL2/PKGBUILD
@@ -10,7 +10,7 @@ source=('git+https://github.com/ps5-payload-dev/SDL.git')
 sha256sums=('SKIP')
 groups=('ps5-payload-dev' 'ps5-payload-sdl2')
 depends=('ps5-payload-libsamplerate')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/SDL2_gfx/PKGBUILD
+++ b/SDL2_gfx/PKGBUILD
@@ -8,6 +8,7 @@ license=(zlib)
 source=("https://www.ferzkopp.net/Software/SDL2_gfx/SDL2_gfx-${pkgver}.tar.gz")
 sha256sums=('63e0e01addedc9df2f85b93a248f06e8a04affa014a835c2ea34bfe34e576262')
 options=(!strip libtool staticlibs)
+makedepends=('ps5-payload-sdk')
 depends=('ps5-payload-sdl2')
 groups=('ps5-payload-dev' 'ps5-payload-sdl2')
 

--- a/SDL2_image/PKGBUILD
+++ b/SDL2_image/PKGBUILD
@@ -9,7 +9,7 @@ options=(!strip libtool staticlibs)
 source=("https://github.com/libsdl-org/SDL_image/releases/download/release-${pkgver}/SDL2_image-${pkgver}.tar.gz")
 sha256sums=('8f486bbfbcf8464dd58c9e5d93394ab0255ce68b51c5a966a918244820a76ddc')
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-openlibm')
 depends=('ps5-payload-sdl2'
 	 'ps5-payload-libpng'
 	 'ps5-payload-libjpeg-turbo'

--- a/SDL2_mixer/PKGBUILD
+++ b/SDL2_mixer/PKGBUILD
@@ -9,7 +9,7 @@ options=(!strip libtool staticlibs)
 source=("${url}/releases/download/release-${pkgver}/SDL2_mixer-${pkgver}.tar.gz")
 sha256sums=('SKIP')
 groups=('ps5-payload-dev' 'ps5-payload-sdl2')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-sdl2')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/SDL2_ttf/PKGBUILD
+++ b/SDL2_ttf/PKGBUILD
@@ -9,7 +9,7 @@ options=(!strip libtool staticlibs)
 source=("${url}/release/SDL2_ttf-${pkgver}.tar.gz")
 sha256sums=('d48cbd1ce475b9e178206bf3b72d56b66d84d44f64ac05803328396234d67723')
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-openlibm')
 depends=('ps5-payload-sdl2' 'ps5-payload-freetype' 'ps5-payload-harfbuzz')
 
 prepare() {

--- a/a52dec/PKGBUILD
+++ b/a52dec/PKGBUILD
@@ -9,7 +9,7 @@ source=("https://distfiles.adelielinux.org/source/a52dec/a52dec-$pkgver.tar.gz")
 sha256sums=('03c181ce9c3fe0d2f5130de18dab9bd8bc63c354071515aa56983c74a9cffcc9')
 options=(!strip libtool staticlibs)
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-openlibm')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/curl/PKGBUILD
+++ b/curl/PKGBUILD
@@ -10,7 +10,7 @@ sha256sums=('40df79166e74aa20149365e11ee4c798a46ad57c34e4f68fd13100e2c9a91946')
 options=(!strip libtool staticlibs)
 groups=('ps5-payload-dev')
 depends=('ps5-payload-zlib' 'ps5-payload-openssl')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libpsl')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/devilutionx/PKGBUILD
+++ b/devilutionx/PKGBUILD
@@ -9,7 +9,7 @@ source=("https://github.com/diasurgical/devilutionX/releases/download/$pkgver/de
 sha256sums=('dfe7894dd4dfa5fd2375d708aaa6837eef3986ccac248345a7988059a507de6a')
 options=(!strip libtool staticlibs)
 groups=('ps5-payload-dev' 'ps5-payload-game')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 depends=('ps5-payload-zlib' 'ps5-payload-bzip2' 'ps5-payload-libsodium'
 	 'ps5-payload-sdl2')
 

--- a/eduke32/PKGBUILD
+++ b/eduke32/PKGBUILD
@@ -8,7 +8,7 @@ license=('GPL')
 options=(!strip libtool staticlibs)
 source=("http://dukeworld.duke4.net/eduke32/synthesis/20240725-10593-19c21b9ab/eduke32_src_20240725-10593-19c21b9ab.tar.xz")
 sha256sums=('SKIP')
-makedepends=('ps5-payload-sdl2' 'ps5-payload-flac') # 'ps5-payload-libvorbis')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx' 'ps5-payload-openlibm' 'ps5-payload-sdl2' 'ps5-payload-flac') # 'ps5-payload-libvorbis')
 groups=('ps5-payload-dev' 'ps5-payload-game')
 
 prepare() {

--- a/fast_float/PKGBUILD
+++ b/fast_float/PKGBUILD
@@ -9,7 +9,7 @@ source=("$url/archive/v$pkgver.tar.gz")
 sha256sums=('4458aae4b0eb55717968edda42987cabf5f7fc737aee8fede87a70035dba9ab0')
 options=(!strip libtool staticlibs)
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/fbneo/PKGBUILD
+++ b/fbneo/PKGBUILD
@@ -7,7 +7,7 @@ license=('custom')
 url="https://github.com/ps5-payload-dev/FBNeo"
 source=("git+https://github.com/ps5-payload-dev/FBNeo.git#branch=ps5")
 sha256sums=('SKIP')
-makedepends=('ps5-payload-sdk' 'ps5-payload-sdl2' 'ps5-payload-sdl2_image')
+makedepends=('ps5-payload-sdk' 'ps5-payload-sdl2' 'ps5-payload-sdl2_image' 'ps5-payload-libcxx' 'ps5-payload-openlibm')
 groups=('ps5-payload-dev' 'ps5-payload-game')
 options=(!strip libtool staticlibs)
 

--- a/file/PKGBUILD
+++ b/file/PKGBUILD
@@ -8,7 +8,7 @@ url='https://www.darwinsys.com/file/'
 options=(!strip libtool staticlibs)
 source=("https://astron.com/pub/file/file-$pkgver.tar.gz")
 sha256sums=('c9cc77c7c560c543135edc555af609d5619dbef011997e988ce40a3d75d86088')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-openlibm')
 depends=('ps5-payload-zlib' 'ps5-payload-xz' 'ps5-payload-bzip2')
 groups=('ps5-payload-dev')
 

--- a/giflib/PKGBUILD
+++ b/giflib/PKGBUILD
@@ -9,6 +9,7 @@ source=("https://downloads.sourceforge.net/project/giflib/giflib-5.x/giflib-${pk
 sha256sums=('be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb')
 groups=('ps5-payload-dev')
 options=(!strip libtool staticlibs)
+makedepends=('ps5-payload-sdk')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/glm/PKGBUILD
+++ b/glm/PKGBUILD
@@ -8,7 +8,7 @@ url="http://glm.g-truc.net"
 options=(!strip libtool staticlibs)
 source=("https://github.com/g-truc/glm/archive/refs/tags/${pkgver}.tar.gz")
 sha256sums=('SKIP')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 groups=('ps5-payload-dev')
 
 

--- a/harfbuzz/PKGBUILD
+++ b/harfbuzz/PKGBUILD
@@ -10,7 +10,7 @@ source=("https://github.com/harfbuzz/harfbuzz/releases/download/$pkgver/harfbuzz
 sha256sums=('a41b272ceeb920c57263ec851604542d9ec85ee3030506d94662067c7b6ab89e')
 groups=('ps5-payload-dev')
 depends=('ps5-payload-freetype')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 
 prepare() {
     export PS5_PAYLOAD_SDK=/opt/ps5-payload-sdk

--- a/imgui/PKGBUILD
+++ b/imgui/PKGBUILD
@@ -18,7 +18,7 @@ sha256sums=('6e62c87252e6b3725ba478a1c04dc604aa0aaeec78fedcf4011f1e52548f4cc9'
 options=(!strip libtool staticlibs)
 groups=('ps5-payload-dev')
 depends=('ps5-payload-sdl2')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/json-c/PKGBUILD
+++ b/json-c/PKGBUILD
@@ -9,6 +9,7 @@ options=(!strip libtool staticlibs)
 source=("https://github.com/json-c/json-c/archive/refs/tags/json-c-0.17-20230812.tar.gz")
 sha256sums=('024d302a3aadcbf9f78735320a6d5aedf8b77876c8ac8bbb95081ca55054c7eb')
 groups=('ps5-payload-dev')
+makedepends=('ps5-payload-openlibm')
 depends=('ps5-payload-sdk')
 
 prepare() {

--- a/lakesnes/PKGBUILD
+++ b/lakesnes/PKGBUILD
@@ -9,8 +9,7 @@ options=(!strip libtool staticlibs)
 source=('git+https://github.com/ps5-payload-dev/LakeSnes.git')
 sha256sums=('SKIP')
 groups=('ps5-payload-dev' 'ps5-payload-game')
-depends=('ps5-payload-sdl2')
-makedepends=('ps5-payload-sdl2')
+makedepends=('ps5-payload-sdk' 'ps5-payload-sdl2')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/lbreakouthd/PKGBUILD
+++ b/lbreakouthd/PKGBUILD
@@ -8,7 +8,8 @@ license=('GPL3')
 options=(!strip libtool staticlibs)
 source=("https://downloads.sourceforge.net/project/lgames/lbreakouthd/lbreakouthd-${pkgver}.tar.gz")
 sha256sums=('SKIP')
-makedepends=('ps5-payload-sdl2_ttf' 'ps5-payload-sdl2_image' 'ps5-payload-sdl2_mixer')
+makedepends=('ps5-payload-sdl2_ttf' 'ps5-payload-sdl2_image' 'ps5-payload-sdl2_mixer'
+	'ps5-payload-sdk' 'ps5-payload-libcxx' 'ps5-payload-libiconv' 'ps5-payload-openlibm')
 groups=('ps5-payload-dev' 'ps5-payload-game')
 
 prepare() {

--- a/libdeflate/PKGBUILD
+++ b/libdeflate/PKGBUILD
@@ -9,6 +9,7 @@ options=(!strip libtool staticlibs)
 source=("https://github.com/ebiggers/libdeflate/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('SKIP')
 groups=('ps5-payload-dev')
+makedepends=('ps5-payload-sdk')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/libevent/PKGBUILD
+++ b/libevent/PKGBUILD
@@ -10,7 +10,7 @@ source=(https://github.com/libevent/libevent/releases/download/release-${pkgver}
 sha256sums=('92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb')
 
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk' 'ps5-payload-zlib')
+makedepends=('ps5-payload-sdk' 'ps5-payload-zlib' 'ps5-payload-openlibm')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/libjpeg-turbo/PKGBUILD
+++ b/libjpeg-turbo/PKGBUILD
@@ -8,7 +8,7 @@ license=('IJG')
 options=(!strip libtool staticlibs)
 source=("https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/${pkgver}/libjpeg-turbo-${pkgver}.tar.gz")
 sha256sums=('SKIP')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-openlibm')
 groups=('ps5-payload-dev')
 
 prepare() {

--- a/libmad/PKGBUILD
+++ b/libmad/PKGBUILD
@@ -9,7 +9,7 @@ source=("https://codeberg.org/tenacityteam/libmad/releases/download/${pkgver}/li
 sha256sums=('0f6bfb36c554075494b5fc2c646d08de7364819540f23bab30ae73fa1b5cfe65')
 options=(!strip libtool staticlibs)
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 
 
 prepare() {

--- a/libutp/PKGBUILD
+++ b/libutp/PKGBUILD
@@ -9,7 +9,7 @@ options=(!strip libtool staticlibs)
 source=(git+https://github.com/transmission/libutp.git)
 sha256sums=('SKIP')
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/libvorbis/PKGBUILD
+++ b/libvorbis/PKGBUILD
@@ -9,7 +9,7 @@ source=("https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-$pkgver.tar.g
 sha256sums=('0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab')
 options=(!strip libtool staticlibs)
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx' 'ps5-payload-libogg')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/libvpx/PKGBUILD
+++ b/libvpx/PKGBUILD
@@ -8,7 +8,7 @@ license=(custom:BSD)
 options=(!strip libtool staticlibs)
 source=("https://chromium.googlesource.com/webm/libvpx/+archive/v1.14.1.tar.gz")
 sha256sums=('SKIP')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx' 'ps5-payload-openlibm')
 groups=('ps5-payload-dev')
 
 prepare() {

--- a/libwebp/PKGBUILD
+++ b/libwebp/PKGBUILD
@@ -8,7 +8,7 @@ license=('BSD')
 options=(!strip libtool staticlibs)
 source=("https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-$pkgver.tar.gz")
 sha256sums=('61f873ec69e3be1b99535634340d5bde750b2e4447caa1db9f61be3fd49ab1e5')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-openlibm')
 depends=('ps5-payload-zlib')
 groups=('ps5-payload-dev')
 

--- a/libyuv/PKGBUILD
+++ b/libyuv/PKGBUILD
@@ -11,6 +11,7 @@ source=(git+${url}#commit=${_commit}
 sha256sums=(SKIP
             1106101935d0343538dd1399c5cf87c9534468b392cfc2ec8627e2e34553b096)
 options=(!strip libtool staticlibs)
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/llvm/PKGBUILD
+++ b/llvm/PKGBUILD
@@ -17,7 +17,7 @@ sha256sums=('8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a'
             '1b7d7b8d1cdaa6c4fc1d76f6cc339fe1e5b4d3a99a0cce847dff81464fb7e938'
             'd3ffc972a7b88dbe2d9ff1fad6e9ab9042c22d48faf2041f5fb7524b86cef1bd')
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx' 'ps5-payload-openlibm')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/love/PKGBUILD
+++ b/love/PKGBUILD
@@ -11,6 +11,7 @@ options=(!strip libtool staticlibs)
 groups=('ps5-payload-dev')
 makedepends=('ps5-payload-sdk' 'ps5-payload-luajit'
 	     'ps5-payload-freetype' 'ps5-payload-sdl2' 'ps5-payload-openal'
+	     'ps5-payload-libcxx' 'ps5-payload-openlibm' 'ps5-payload-libmodplug'
 	     'ps5-payload-libvorbis' 'ps5-payload-libtheora' 'ps5-payload-mpg123')
 
 prepare() {

--- a/lua/PKGBUILD
+++ b/lua/PKGBUILD
@@ -9,6 +9,7 @@ options=(!strip libtool staticlibs)
 source=("https://www.lua.org/ftp/lua-$pkgver.tar.gz")
 sha256sums=('7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88')
 groups=('ps5-payload-dev')
+makedepends=('ps5-payload-sdk' 'ps5-payload-openlibm')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/luajit/PKGBUILD
+++ b/luajit/PKGBUILD
@@ -9,7 +9,7 @@ options=(!strip libtool staticlibs)
 source=("git+https://github.com/LuaJIT/LuaJIT.git#commit=f9140a622a0c44a99efb391cc1c2358bc8098ab7")
 sha256sums=('SKIP')
 groups=('ps5-payload-dev')
-
+makedepends=('ps5-payload-sdk' 'ps5-payload-openlibm' 'ps5-payload-libcxx')
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then
 	export PS5_PAYLOAD_SDK=/opt/ps5-payload-sdk

--- a/mednafen/PKGBUILD
+++ b/mednafen/PKGBUILD
@@ -8,7 +8,9 @@ license=('GPLv2')
 options=(!strip libtool staticlibs)
 source=("https://mednafen.github.io/releases/files/mednafen-$pkgver.tar.xz")
 sha256sums=('de7eb94ab66212ae7758376524368a8ab208234b33796625ca630547dbc83832')
-makedepends=('ps5-payload-sdk' 'ps5-payload-sdl2' 'ps5-payload-flac')
+makedepends=('ps5-payload-sdk' 'ps5-payload-sdl2' 'ps5-payload-flac'
+	'ps5-payload-libcxx' 'ps5-payload-libsamplerate' 'ps5-payload-openlibm'
+	'ps5-payload-zlib' 'ps5-payload-libiconv')
 groups=('ps5-payload-dev' 'ps5-payload-game')
 
 prepare() {

--- a/mesa/PKGBUILD
+++ b/mesa/PKGBUILD
@@ -11,7 +11,9 @@ source=("https://mesa.freedesktop.org/archive/older-versions/22.x/mesa-$pkgver.t
 sha256sums=('da838eb2cf11d0e08d0e9944f6bd4d96987fdc59ea2856f8c70a31a82b355d89')
 
 groups=('ps5-payload-dev' 'ps5-payload-gl')
-makedepends=('ps5-payload-sdk' 'ps5-payload-llvm')
+makedepends=('ps5-payload-sdk' 'ps5-payload-llvm' 'ps5-payload-libcxx'
+	'ps5-payload-openlibm' 'ps5-payload-zlib' 'ps5-payload-expat'
+	'ps5-payload-zstd')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/openal/PKGBUILD
+++ b/openal/PKGBUILD
@@ -11,7 +11,7 @@ sha256sums=('7e1fecdeb45e7f78722b776c5cf30bd33934b961d7fd2a11e0494e064cc631ce')
 
 groups=('ps5-payload-dev')
 makedepends=('ps5-payload-sdk' 'ps5-payload-ffmpeg' 'ps5-payload-libsndfile'
-	     'ps5-payload-sdl2')
+	     'ps5-payload-sdl2' 'ps5-payload-libcxx')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/openmp/PKGBUILD
+++ b/openmp/PKGBUILD
@@ -9,7 +9,7 @@ options=(!strip libtool staticlibs)
 source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-${pkgver}/llvm-project-${pkgver}.src.tar.xz")
 sha256sums=('0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a')
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/osmesa/PKGBUILD
+++ b/osmesa/PKGBUILD
@@ -11,7 +11,7 @@ source=('git+https://github.com/starseeker/osmesa.git'
 sha256sums=('SKIP'
 	    '0c1fda27342a22c6f140950e9c51c47651f4092119d6971f857c8fd7769723c7')
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx' 'ps5-payload-glu')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then

--- a/scummvm/PKGBUILD
+++ b/scummvm/PKGBUILD
@@ -9,7 +9,7 @@ source=("https://downloads.scummvm.org/frs/scummvm/${pkgver}/scummvm-${pkgver}.t
 sha256sums=('7e97f4a13d22d570b70c9b357c941999be71deb9186039c87d82bbd9c20727b7')
 options=(!strip libtool staticlibs)
 groups=('ps5-payload-dev' 'ps5-payload-game')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 depends=('ps5-payload-libpng' 'ps5-payload-libtheora' 'ps5-payload-sdl2'
 	 'ps5-payload-sdl2_net' 'ps5-payload-flac' 'ps5-payload-libvorbis'
 	 'ps5-payload-libmad' 'ps5-payload-freetype' 'ps5-payload-libmpeg2'

--- a/sqlite/PKGBUILD
+++ b/sqlite/PKGBUILD
@@ -8,6 +8,7 @@ url="https://www.sqlite.org/"
 options=(!strip libtool staticlibs)
 source=(https://www.sqlite.org/2024/sqlite-src-3460100.zip)
 sha256sums=('SKIP')
+makedepends=('ps5-payload-sdk')
 
 groups=('ps5-payload-dev')
 

--- a/tinyxml2/PKGBUILD
+++ b/tinyxml2/PKGBUILD
@@ -8,7 +8,7 @@ license=('apache')
 options=(!strip libtool staticlibs)
 source=( "https://github.com/leethomason/tinyxml2/archive/${pkgver}.tar.gz" )
 sha256sums=('3bdf15128ba16686e69bce256cc468e76c7b94ff2c7f391cc5ec09e40bff3839')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 groups=('ps5-payload-dev')
 
 prepare() {

--- a/websrv/PKGBUILD
+++ b/websrv/PKGBUILD
@@ -8,7 +8,7 @@ url="https://github.com/ps5-payload-dev/websrv"
 source=("git+https://github.com/ps5-payload-dev/websrv.git")
 sha256sums=('SKIP')
 groups=('ps5-payload-dev' 'ps5-payload-daemon')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libmicrodns' 'ps5-payload-libsmb2')
 depends=('ps5-payload-libmicrohttpd')
 options=(!strip libtool staticlibs)
 

--- a/zstd/PKGBUILD
+++ b/zstd/PKGBUILD
@@ -9,7 +9,7 @@ options=(!strip libtool staticlibs)
 source=(https://github.com/facebook/zstd/releases/download/v${pkgver}/zstd-${pkgver}.tar.gz)
 sha256sums=('8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1')
 groups=('ps5-payload-dev')
-makedepends=('ps5-payload-sdk')
+makedepends=('ps5-payload-sdk' 'ps5-payload-libcxx')
 
 prepare() {
     if [ -z "${PS5_PAYLOAD_SDK}" ]; then


### PR DESCRIPTION
Currently, there are unlisted build dependencies for several PKGBUILDs. The ci-*.sh build scripts don't fail, because they have manual build orders that ensure the dependencies are satisfied. But tooling that builds each package in a clean environment or automatically calculates a rebuild order don't work without a complete dependency list.

This PR adds the missing build-time ps5-payload-dev dependencies to the `makedepends` array of each PKGBUILD.

Tested with the ps5-payload-libs GitHub CI job to make sure nothing weird and unexpected would happen.

See issue #14.