### PR TITLE
update json-c to 0.18, fix compile with cmake 4.3.0

### DIFF
--- a/json-c/PKGBUILD
+++ b/json-c/PKGBUILD
@@ -6,8 +6,8 @@ url="https://github.com/json-c/json-c/wiki"
 license=('MIT')
 arch=('any')
 options=(!strip libtool staticlibs)
-source=("https://github.com/json-c/json-c/archive/refs/tags/json-c-0.17-20230812.tar.gz")
-sha256sums=('024d302a3aadcbf9f78735320a6d5aedf8b77876c8ac8bbb95081ca55054c7eb')
+source=("https://github.com/json-c/json-c/archive/refs/tags/json-c-0.18-20240915.tar.gz")
+sha256sums=('3112c1f25d39eca661fe3fc663431e130cc6e2f900c081738317fba49d29e298')
 groups=('ps5-payload-dev')
 makedepends=('ps5-payload-openlibm')
 depends=('ps5-payload-sdk')
@@ -20,11 +20,12 @@ prepare() {
 
 build() {
     source "${PS5_PAYLOAD_SDK}/toolchain/prospero.sh"
-    cd json-c-json-c-0.17-20230812
+    cd json-c-json-c-0.18-20240915
 
     ${CMAKE} -DCMAKE_BUILD_TYPE=Release \
+	     -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 	     -DCMAKE_C_FLAGS="-Wno-unreachable-code-generic-assoc" \
-	     -B build \
+         -B build \
              -S .
     ${MAKE} -C build
 }
@@ -32,7 +33,7 @@ build() {
 
 package() {
     source "${PS5_PAYLOAD_SDK}/toolchain/prospero.sh"
-    cd json-c-json-c-0.17-20230812
+    cd json-c-json-c-0.18-20240915
 
     ${MAKE} -C build DESTDIR="${pkgdir}/${PS5_PAYLOAD_SDK}/target" install
 }


### PR DESCRIPTION
CMake requires specific args to compile projects using CMake 3.5 syntax. This is an upstream issue with these projects, it's just being revealed to me because Fedora is shipping CMake 4.3.0 which is erroring out and refusing to build without passing 	`-DCMAKE_POLICY_VERSION_MINIMUM=3.5`. With that passed it builds/works fine.

Error:

```CMake Error at tests/CMakeLists.txt:1 (cmake_minimum_required):

 Compatibility with CMake < 3.5 has been removed from CMake.



 Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax

 to tell CMake that the project requires at least <min> but has been updated

 to work with policies introduced by <max> or earlier.



 Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.





-- Configuring incomplete, errors occurred!

==> ERROR: A failure occurred in build().

   Aborting... 
```

Updated to latest as well.
