### PR TITLE
libmad fix for compiling with cmake 4.3.0

### DIFF
--- a/libmad/PKGBUILD
+++ b/libmad/PKGBUILD
@@ -23,8 +23,9 @@ build() {
     cd libmad
 
     ${CMAKE} -DCMAKE_BUILD_TYPE=Release \
-	     -B build \
-             -S .
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+	    -B build \
+        -S .
     ${MAKE} -C build
 }
 


### PR DESCRIPTION
CMake requires specific args to compile projects using CMake 3.5 syntax. This is an upstream issue with these projects, it's just being revealed to me because Fedora is shipping CMake 4.3.0 which is erroring out and refusing to build without passing 	`-DCMAKE_POLICY_VERSION_MINIMUM=3.5`. With that passed it builds/works fine.

Error:

```CMake Error at tests/CMakeLists.txt:1 (cmake_minimum_required):

 Compatibility with CMake < 3.5 has been removed from CMake.



 Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax

 to tell CMake that the project requires at least <min> but has been updated

 to work with policies introduced by <max> or earlier.



 Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.





-- Configuring incomplete, errors occurred!

==> ERROR: A failure occurred in build().

   Aborting... 
```