### PR TITLE
libvorbis fix for compiling with cmake 4.3.0

### DIFF
--- a/libvorbis/PKGBUILD
+++ b/libvorbis/PKGBUILD
@@ -22,8 +22,9 @@ build() {
     cd libvorbis-$pkgver
 
     ${CMAKE} -DCMAKE_BUILD_TYPE=Release \
-	     -B build \
-             -S .
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -B build \
+        -S .
     ${MAKE} -C build
 }
 


### PR DESCRIPTION
same as https://github.com/ps5-payload-dev/pacbrew-repo/pull/22