### PR TITLE
rmlui: Fix CMake flag typo

### DIFF
--- a/rmlui/PKGBUILD
+++ b/rmlui/PKGBUILD
@@ -24,7 +24,7 @@ build() {
 
     ${CMAKE} -DCMAKE_BUILD_TYPE=Release \
 	     -DRMLUI_LUA_BINDINGS=YES \
-	     -DRML_LUA_BINDINGS_LIBRARY=luajit \
+	     -DRMLUI_LUA_BINDINGS_LIBRARY=luajit \
 	     -B build \
              -S .
     ${MAKE} -C build


### PR DESCRIPTION
Building rmlui with `-DRML_LUA_BINDINGS` produces this error:

```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:290 (message):
  Could NOT find Lua (missing: LUA_LIBRARIES LUA_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:654 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake/Modules/FindLua.cmake:341 (find_package_handle_standard_args)
  CMake/Dependencies.cmake:34 (find_package)
  CMakeLists.txt:120 (include)
```

Or this warning if CMake finds LuaJIT anyway:

```
CMake Warning:
  Manually-specified variables were not used by the project:

    RML_LUA_BINDINGS_LIBRARY
```

Specifying the full option `-DRMLUI_LUA_BINDING` fixes both.

Tested with ps5-payload-libs workflow. (Force-pushed to fix my own commit message typo.)